### PR TITLE
Fix_[Client] : Fix not initializing sessionStorage offset

### DIFF
--- a/client/src/pages/Mainpage.js
+++ b/client/src/pages/Mainpage.js
@@ -62,21 +62,27 @@ const Loading = styled.div`
 `;
 
 const ErrorMsg = styled.section`
-  width: 40rem;
+  margin: 0 auto;
+  max-width: 40rem;
   padding-top: 92px;
   display: flex;
   justify-content: space-between;
+  svg {
+    width: 50%;
+    height: 100%;
+  }
   & > div {
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
   }
+
   h1 {
     font-family: 'Inter';
     font-style: normal;
     font-weight: 700;
-    font-size: 40px;
+    font-size: 2rem;
     line-height: 48px;
 
     color: #6268ff;
@@ -86,11 +92,26 @@ const ErrorMsg = styled.section`
     font-family: 'Inter';
     font-style: normal;
     font-weight: 600;
-    font-size: 24px;
+    font-size: 1.2rem;
     line-height: 29px;
 
     span {
       color: #ff9a62;
+    }
+  }
+  @media screen and (max-width: 485px) {
+    width: 100%;
+    flex-direction: column;
+    padding: 0;
+
+    svg {
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 1.5rem;
+    }
+    p {
+      font-size: 1rem;
     }
   }
 `;
@@ -98,27 +119,34 @@ const Mainpage = ({
   togglePick,
   filteredData,
   pickItems,
-
+  offset,
   setFestivalData,
   setFilteredData,
 }) => {
+  console.log('Mainpage 렌더링');
   const [searchParams, setSearchParams] = useSearchParams();
   const observerTargetEl = useRef(null);
   const [hasNextPage, setHasNextPage] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [query, setQuery] = useState(searchParams.get('query'));
-  let offset = +sessionStorage.getItem('offset') || 0;
-  console.log('Mainpage offset', offset);
+
+  console.log(
+    'Mainpage filteredData.length ,isLoading, offset : ',
+    filteredData.length,
+    isLoading,
+    offset
+  );
 
   const navigate = useNavigate();
-
+  console.log(navigate);
   const fetchData = useCallback(async () => {
+    console.log('fetchDaata offset', offset);
     setIsLoading(true);
 
     try {
       const response = await axios.get(
         `${process.env.REACT_APP_SERVER_URL}/festivals`,
-        { params: { limit: 8, offset, query } }
+        { params: { limit: 8, offset: offset.current, query } }
       );
 
       const festivals = response.data;
@@ -128,7 +156,7 @@ const Mainpage = ({
       setHasNextPage(festivals.length === 8);
 
       if (festivals.length) {
-        offset += 8;
+        offset.current += 8;
         sessionStorage.setItem('offset', offset);
       }
 
@@ -152,16 +180,23 @@ const Mainpage = ({
       console.log(error);
     }
   };
-
   useEffect(() => {
+    console.log('useEffect!!');
+    console.log(observerTargetEl.current, hasNextPage);
     if (!observerTargetEl.current || !hasNextPage) return;
     const callback = (entries, observer) => {
-      if (offset === 0) {
+      console.log(
+        'callback함수 호출, offset, enrties[0].isInterSecting : ',
+        offset,
+        entries[0].isIntersecting
+      );
+      if (offset.current === 0) {
         fetchData();
         return;
       }
 
       if (entries[0].isIntersecting) {
+        console.log('intersecting true!!');
         fetchData();
       }
     };


### PR DESCRIPTION
 - 세션 스토리지가 초기화되지 않는 에러를 수정합니다.

# PR Type

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# requested branch

- ex) `feat/bugfix_sessionStorage_refresh` -> `dev`

# Motivation, Problem
### PS1

- 문제
    - 새로고침시 sessionStorage가 초기화가 안되고 값이 계속 증가하는 문제
           <img src="https://user-images.githubusercontent.com/95751232/203731564-519378f3-8002-4efa-bdf3-0d2bb5b5a649.gif" width="400" height="250" />

    
- 원인
    - 새로고침을 해주면 세션스토리지에서 offset을 초기화 해주는 코드가 App의 useEffect에 들어가 있다.
        
        ```jsx
        sessionStorage.getItem('offset') && sessionStorage.removeItem('offset');
        ```
        
    - 문제는 실행 순서에 있었다.
        1. 새로고침
        2. App이 렌더링
        3. Mainpage 렌더링
            - 세션스토리지에 저장된 offset으로 서버에 요청을 보낸다.
                
                ```jsx
                let offset = +sessionStorage.getItem('offset') || 0;
                ```
                
        4. App의 useEffect 호출
            - 세션스토리지를 초기화해주는 함수 호출
    - 세션스토리지를 초기화 해주는 4번이 실행되기 전에 3번인 메인페이지가 먼저 렌더링 되면서 초기화 되지 않은 offset을 가지고 서버에 요청을 보내게 되는 것이다.
    - 새로고침할 App의 useEffect가 실행되기 전에 Mainpage가 렌더링되면서 삭제되지 않은 offset을 가지고 데이터를 또 받아온다. 그러면  앱이 새로고침되면서
        - 8~15
        - 한번더 새로고침하면 16~23
        - 한번더 새로고침하면 24~31 이렇게 festivalData가 초기화가 되다가
        - 나중에는 offset이 받아올 수 있는 데이터를 넘었을 때 (데이터 개수가 30개 인데 offset이 40으로 변하여 그대로 서버에 요청을 보내면 빈배열을 받아오는 에러로 판단할 수 있다.
           
- 해결 방안
    - 새로고침을 하면 offset을 0으로 초기화해주는 게 목적이다.
    - Mainpage에서 offset을 세션스토리지에서 받아오지 말고 0으로 시작하면 새로고침을 할 때마다 Mainpage가 렌더링 되면서 offset이 0으로 초기화가 되어 빈배열을 받아오는 에러가 사라질 수 있었다.
    - 하지만 위와 같은 방법으로 할 때 에러가 또 발생한다.  PS2에서 !

### PS2

- 문제
    
    메인페이지에서 특정 축제페이지를 클릭하면 상세페이지로 넘어가게 되는데 상세페이지에서 다시 뒤로가기를 눌러 메인페이지로 가면 offset이 0이 되면서 기존 데이터와 중복되는 데이터를 8개 불러오는 문제가 발생한다.
         <img src="https://user-images.githubusercontent.com/95751232/203731758-c0c5a505-7583-4915-9b59-0e1f6f473fa9.png" width="400" />
    
- 해결방안
    - offset을 App에서 useRef로 0을 세팅해주고 해당 offset을 Mainpage에 props로 넘겨준다
    - App으로 부터 offset을 전달받은 mainpage가 서버로 요청을 보내고 받아온 데이터를 다시 App으로 상태를 올려주어 축제데이터들이 채워지게 되고 채워진 데이터들이 다시 Mainpage로 채워지는 구조다.
    - 특정 페이지를 갖다가 다시 돌아왔을 때는 offset은 App에 저장되어 있기 때문에 상태가 유지되고 Mainpage가 렌더링 될때 props로 상태유지가 된 offset을 받아와 서버로 보내기 때문에 중복되지 않는 데이터를 받아올 수 있다.
             <img src="https://user-images.githubusercontent.com/95751232/203731804-8636cf30-34fa-4b77-a934-32efa0835633.png" width="400"  />
        
 - 중복 없이 offset을 서버에 요청하여 받아오기 성공 시연
                 <img src="https://user-images.githubusercontent.com/95751232/203731836-c1fb5689-3b65-4fe0-b899-9c96c888d1b0.gif" width="400"  />



