### PR TITLE
Fix_[Client, Server]: Fix CSS X browsing error

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -28,7 +28,6 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <link rel="stylesheet" href="../src/styles/reset.css" />
     <title>React App</title>
   </head>
   <body>

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,3 +1,4 @@
+@import url(./styles/reset.css);
 * {
   margin: 0;
   padding: 0;

--- a/client/src/components/DescTab.js
+++ b/client/src/components/DescTab.js
@@ -14,6 +14,7 @@ const Wrapper = styled.section`
   overflow-y: auto;
   border-radius: 0 0 1rem 1rem;
   padding: 1rem;
+  padding-bottom: 5rem;
 
   h1 {
     font-size: 2rem;
@@ -35,6 +36,7 @@ const Wrapper = styled.section`
   p {
     margin-top: 43px;
     margin-bottom: 21px;
+    line-height: 1.5;
   }
 
   h3 {

--- a/client/src/components/LoginModal.js
+++ b/client/src/components/LoginModal.js
@@ -82,6 +82,7 @@ const ModalContainer = styled.div`
     & > button {
       width: 50%;
       padding-right: 32px;
+      color: gray;
       &:nth-child(1) {
         border-right: 1px solid black;
         padding-left: 32px;

--- a/client/src/components/ReviewTab.js
+++ b/client/src/components/ReviewTab.js
@@ -92,6 +92,12 @@ const ReviewList = styled.section`
     display: none; /* for Chrome, Safari, and Opera */
   }
 
+  .noReview {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
   .pagination {
     display: flex;
     justify-content: center;
@@ -100,7 +106,7 @@ const ReviewList = styled.section`
       width: 2rem;
       height: 2rem;
       margin: 0 0.5rem;
-      border-radius: 0.5rem rem;
+      border-radius: 0.5rem;
       font-size: 1.2rem;
     }
   }
@@ -151,79 +157,6 @@ const ReviewTab = ({ festival, authState }) => {
     }
     console.log('reviews', reviews);
   }, [festivalId, offset]);
-  /* totalReview : 18
-  unit : 5
-  pageLength : totalReview % unit === 0 ? totalReview/unit : parseInt(totalReview/unit) + 1  (나누어 떨어지면 그대로, 나누어떨어지지 않으면 +1)
-  page : (현재 페이지)
-  page    1  2  3  ~~ n
-  offset  0  5  10 ~~ (n-1)*5 <- 페이지로부터 계산
-  level  : page % 5 === 0 ? page / 5  : parseInt(page / 5) + 1
-  
-  
-  limit(계속 5개)
-  
-  0. 1페이지에 5개 리뷰씩 5페이지씩 보여준다고 가정
-  1. 처음 렌더링 되었을 때 
-      a. 페이지 버튼
-            총 리뷰의 개수를 통해 몇개의 페이지가 생성되는지 계산, 페이지 개수에 따라 몇개의 번들이 만들어지는지 계산 
-         
-            pageLength<5? Array(pageLength) : Array(5) 맵핑할 때 [1+5*(level -1), 2+5*(level -1), 3+5*(level -1), 4+5*(level -1), 5+5*(level -1)]
-  
-              총 리뷰 3개
-              : 1페이지, 1번들 
-              총 리뷰 6개
-              : 2페이지, 1번들
-              총 리뷰 57개
-              : 11페이지, 3번들
-  
-        i. 2번들 이상일 때
-        
-            offset : 0, 5, 10, 15, 20,        25, 30, 35
-            page   : 1, 2, 3,  4,  5 ,        6,  7,  8
-  
-            현재 page가 1, 6, 11 일때마다 페이지 버튼 바꿔야됨
-                5n-4 (n>=1)
-                (5*0)+1<= page <(5*1)+1 : 1,2,3,4,5 몫 : 0   => 1+(0*5) 2+(0*5) 3+(0*5) 4+(0*5) 5+(0*5) 
-                (5*1)+1<= page <(5*2)+1 : 6,7,8,9,10 몫 : 1 =>  1+(1*5) 2+(1*5) 3+(1*5) 4+(1*5) 5+(1*5) 
-  \
-                1 < ~~~ < 5  
-                5p-4          5p
-                1,2,3,4,5 ==>     몫 : 0  => 1+(0*5) 2+(0*5) 3+(0*5) 4+(0*5) 5+(0*5) 
-                6,7,8,9,10 ==>    몫 : 1  => 1+(1*5) 2+(1*5) 3+(1*5) 4+(1*5) 5+(1*5) 
-                11,12,13,14,15 >  몫 : 2
-                2페이지면
-                0.2로만들고 
-                parseInt(0.2) => 0
-  
-                해야할 것 : 7이 5와 10사이에 있는지 판단이 가능하면됨
-  
-                7페이지면 
-                0.7로만들고
-                parseInt(0.7) => 
-  
-                !10으로 나누어 소숫점을 만들어준 다음 반올림을 하고 여기에 다시 10을 곱해주어서 정수 반올림을 한다. 같은 방법으로 올림은 Math.ceil, 내림은 Math.floor을 하면 된다.
-  
-      b. 화살표 버튼
-            < : 비활성화
-            > : page<=5? 비활성화 : 활성화
-  
-  
-  2. 각 nav버튼을 누를 때 
-      특정 페이지의 다섯개의 리뷰를 불러오기 axios.get(limit=5, offset=)
-      
-  
-      a. 페이지 버튼을 누를 때 
-         ex) 2페이지면 axios.get(limit = 5, offset = (2-1)*5)
-      b. 화살표 번호를 누를 때
-         < 버튼 
-            - axios.get(limit= 5, offset = ((page-2)*5)로 이동
-            - page가 0이면 비활성화
-  
-         > 버튼
-            - axios.get(limit= 5, offset = (page*5)로 이동
-            - 마지막 page면 비활성화 (page === pageLength)
-  
-  */
 
   useEffect(() => {
     //# 특정 축제에 대한 리뷰글들을 불러온다.
@@ -316,7 +249,7 @@ const ReviewTab = ({ festival, authState }) => {
           </div>
         )}
         {reviews.length === 0 ? (
-          <>리뷰가 등록되어있지 않습니다.</>
+          <div className="noReview">리뷰가 등록되어있지 않습니다.</div>
         ) : (
           <>
             {reviews.map((review) => (
@@ -335,23 +268,6 @@ const ReviewTab = ({ festival, authState }) => {
               >
                 &lt;
               </button>
-              {/*
-              
-                현재 레벨에서 5개 이하이면 5개 이하의 버튼을 보여줘야함
-
-                총 페이지 7개
-                레벨 2에선 페이지 2개
-
-                pageLength - (level - 1) * unit < 5 이면
-
-                현재 레벨에서 남은 개수만큼 렌더링
-
-                level * unit
-
-                [1,2,3,4,5]
-                [6,7]
-
-            unit(5)*(level-1) + 1 부터 시작해서 맵핑*/}
 
               {pageLength - (level - 1) * unit < 5
                 ? Array(pageLength - (level - 1) * unit)

--- a/client/src/pages/Detailviewpage.js
+++ b/client/src/pages/Detailviewpage.js
@@ -71,8 +71,9 @@ const Wrapper = styled.section`
     border-radius: 18px;
     box-shadow: 1px 0px 7px rgb(0 0 0 / 22%);
     & > img {
+      width: 100%;
       max-width: 100%;
-      aspect-ratio: 367 / 393;
+      height: 80%;
       border-radius: 1rem;
       padding: 0.5rem;
     }
@@ -88,18 +89,19 @@ const Wrapper = styled.section`
         display: flex;
         align-items: center;
       }
-    }
-    button {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      font-size: 1.1rem;
-      margin-right: 0.5rem;
-      img,
-      svg {
-        width: 25px;
-        height: auto;
-        margin-right: 0.2rem;
+      button {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 1.1rem;
+        margin-right: 0.5rem;
+        color: gray;
+        img,
+        svg {
+          width: 25px;
+          height: auto;
+          margin-right: 0.2rem;
+        }
       }
     }
 
@@ -135,7 +137,6 @@ const Wrapper = styled.section`
       font-weight: 700;
       font-size: 2rem;
       line-height: 42px;
-      background-color: paleturquoise;
     }
 
     ul {
@@ -150,11 +151,11 @@ const Wrapper = styled.section`
       color: #a0a0a0;
     }
 
-    .review {
+    .reviews {
       background-color: white;
       flex: 0 1 auto;
       padding: 0.4rem;
-      /* max-width: 400px; */
+
       width: 100%;
       height: 116px;
       max-height: 116px;
@@ -173,9 +174,22 @@ const Wrapper = styled.section`
           }
         }
       }
+      .noReview {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        color: #a0a0a0;
+      }
     }
     div + div {
       margin-top: 14px;
+    }
+    @media screen and (max-width: 845px) {
+      h1 {
+        font-size: 1.5rem;
+      }
     }
 
     @media (max-width: 485px) {
@@ -395,7 +409,7 @@ const Detailviewpage = ({ togglePick, authState }) => {
           `${process.env.REACT_APP_SERVER_URL}/festivals/${params.festivalId}`,
           { params: { userId: authState.userId } }
         );
-
+        console.log(result.data);
         setSummary(result.data);
         const isPicked = result.data.isPicked;
 
@@ -543,7 +557,7 @@ const Detailviewpage = ({ togglePick, authState }) => {
                 {moment(endDate, 'YYYY.MM.DD').format('YYYY.MM.DD')}
               </li>
             </ul>
-            <div className="review">
+            <div className="reviews">
               {goodReview[0] ? (
                 <>
                   <div className="header">
@@ -556,10 +570,10 @@ const Detailviewpage = ({ togglePick, authState }) => {
                   <p>{goodReview[0].content}</p>
                 </>
               ) : (
-                '리뷰가 등록되어있지 않습니다'
+                <div className="noReview">등록된 리뷰가 없습니다</div>
               )}
             </div>
-            <div className="review">
+            <div className="reviews">
               {badReview[0] ? (
                 <>
                   <div className="header">
@@ -572,7 +586,7 @@ const Detailviewpage = ({ togglePick, authState }) => {
                   <p>{badReview[0].content}</p>
                 </>
               ) : (
-                '리뷰가 등록되어있지 않습니다'
+                <div className="noReview">등록된 리뷰가 없습니다</div>
               )}
             </div>
           </section>

--- a/server/controllers/festivals.js
+++ b/server/controllers/festivals.js
@@ -190,7 +190,11 @@ module.exports = {
       isPicked = isPicked === 1 ? true : false;
       //별점 평균
       const sum = await Reviews.sum('rating', { where: { festivalId } });
-      const average = Number((sum / reviewCount).toFixed(1));
+      let average = 0;
+
+      if (reviewCount !== 0) {
+        average = Number((sum / reviewCount).toFixed(1));
+      }
       //좋아요개수
       const likes = await Picks.count({
         where: { festivalId },

--- a/server/controllers/review/get.js
+++ b/server/controllers/review/get.js
@@ -22,9 +22,10 @@ module.exports = async (req, res) => {
 
     // 특정 축제 평균평점
     const reviewSum = await Reviews.sum('rating', { where: { festivalId } });
-    const average = Number((reviewSum / count).toFixed(1));
-    console.log(rows);
-    //최고값을 가진 것 중에서 제일 최신의 축제
+    let average = 0;
+    if (count !== 0) {
+      average = Number((reviewSum / count).toFixed(1));
+    }
 
     res.json({ count, rows, average });
   } catch (error) {


### PR DESCRIPTION
# PR Type

- [ ]  기능 추가
- [ ]  기능 삭제
- [x]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

# requested branch

- ex) `feat/bugfix-XbrowsingCSS` -> `dev`

# Motivation, Problem ⇒ Changed

## [Client]
1. reset.css가 index.html에서 불러오지 않는 에러를 App.css에서 import로 불러오는 것으로 수정하여 해결합니다.
    <img src="https://user-images.githubusercontent.com/95751232/204729411-833abc98-9fd5-481d-b6f8-04f722e94fdd.png" width="400" height="auto">    
    ```css
    @import url(./styles/reset.css);
    ```
    
2. 적용된 reset.css로 인해 상세페이지에서 p 요소안의 줄어든 글씨 간격을 늘립니다.
    <img src="https://user-images.githubusercontent.com/95751232/204729757-a34317b7-779b-4d8b-bfc5-e0a765fc5fc8.png" width="400" height="auto">    
  
    
3. ios 15버전 업데이트로 버튼 글자 색상이 파란색으로 나오는 에러를 임의로 색상 값을 주어 해결합니다.
    <img src="https://user-images.githubusercontent.com/95751232/204729935-e96e0665-9769-4ab5-8358-86d6a55e2a93.png" width="200">
     <img src="https://user-images.githubusercontent.com/95751232/204729953-32028b95-0b5e-4e69-b58a-b8a3bcb1258b.png" width="200">

4. tablet에서 축제 이미지가 일정하게 나오지 않고 제멋대로 나오는 에러를 aspect-ratio가 아닌 height를 고정된 값을 주어  나오도록 해결합니다. 선별된 리뷰들이 없을 때 나오는 메시지의 요소를 가운데로 정렬하여 UI를 개선합니다.
    <img src="https://user-images.githubusercontent.com/95751232/204730296-2ff942e2-c235-4009-b68d-649489090020.png" width="400" >
    
5. tablet에서 홈페이지 링크가 가려저 안보이는 에러를 padding-bottom을 추가하여 해결합니다.
     <img src="https://user-images.githubusercontent.com/95751232/204730483-2abb632f-dd8a-4034-a405-aec46b26fe25.png" width="400" >


    

## [Server]

1. 리뷰가 없을 때 평균을 계산하는 함수에서 null를 클라이언트에 보내주는 대신 0을 보내주도록 변경합니다.
    
    ```jsx
    // 특정 축제 평균평점
        const reviewSum = await Reviews.sum('rating', { where: { festivalId } });
        let average = 0;
        if (count !== 0) {
          average = Number((reviewSum / count).toFixed(1));
        }
    ```