### PR TITLE
Fix_[Client]: fix not rendering by withdrawal member review

### DIFF
--- a/client/src/components/ReviewItem.js
+++ b/client/src/components/ReviewItem.js
@@ -9,14 +9,12 @@ const Wrapper = styled.div`
   width: 100%;
   min-height: 199px;
   border-bottom: 1px solid #d9d9d9;
-  padding-bottom: 1rem;
+  padding: 1rem;
 
   & + & {
     margin-bottom: 1rem;
   }
   @media (max-width: 485px) {
-    /* max-width: 380px;
-    height: 199px; */
     border: 1px solid #d9d9d9;
     border-radius: 7px;
   }
@@ -73,7 +71,6 @@ const Info = styled.div`
 `;
 
 const Body = styled.div`
-  /* background-color: green; */
   padding-top: 22px;
   padding-left: 16px;
 `;
@@ -151,7 +148,6 @@ export const showRating = (rating, size = 18) => {
 const Review = ({ review, authState, deleteReview }) => {
   const [deleteClicked, setDeleteClicked] = useState(false);
   const { rating, content, createdAt, User, festivalId, id } = review;
-  console.log(review);
   const modalHandler = () => {
     setDeleteClicked(!deleteClicked);
   };
@@ -179,7 +175,7 @@ const Review = ({ review, authState, deleteReview }) => {
               <img src={profileImg} alt="프로필사진" />
               <div className="nicknameAndDate">
                 <ul>
-                  <li>{User.nickname}</li>
+                  <li>{User ? User.nickname : '탈퇴한 회원입니다'}</li>
                   <li>{moment(createdAt).format('YYYY-MM-DD')}</li>
                 </ul>
               </div>

--- a/client/src/pages/Detailviewpage.js
+++ b/client/src/pages/Detailviewpage.js
@@ -359,6 +359,7 @@ const MobileWrapper = styled.section`
 
   p {
     padding: 18px;
+    line-height: 1.5;
   }
 
   .infoList {

--- a/server/controllers/review/get.js
+++ b/server/controllers/review/get.js
@@ -19,6 +19,7 @@ module.exports = async (req, res) => {
       offset: Number(offset),
       limit: Number(limit),
     });
+    console.log(rows);
 
     // 특정 축제 평균평점
     const reviewSum = await Reviews.sum('rating', { where: { festivalId } });


### PR DESCRIPTION
 - 탈퇴한 회원의 리뷰글을 불러올 때 null로 인해 아예 렌더링이 되지 않는 오류를 해결합니다.

# PR Type

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# requested branch

- ex) `feat/bugfix-withdrawal_member_review` -> `dev`

### Problem

- 특정 축제의 상세페이지를 가니깐 아예 화면이 나오지 않으면서 에러가 뜨는 것을 발견하였다.
   <img src="https://user-images.githubusercontent.com/95751232/204819231-50d7f926-b694-4aef-8567-9724af4b9f14.gif" width="400" >

### Cause
- 콘솔 찍힌것을 보니깐 유저가 undefined라고 뜨는 것을 파악했고
    <img src="https://user-images.githubusercontent.com/95751232/204819946-7ac4709f-fa9b-40e6-9b13-b073a32f29e3.png" width="500">
   
- mysql로 조회를 해봤더니 해당 리뷰글을 작성한 유저가 탈퇴한 회원이었다.
    
    ```jsx
    mysql> select * from reviews where festivalId=292961;
    +----+-----------+--------+---------------------+---------------------+------------+--------+
    | id | content   | rating | createdAt           | updatedAt           | festivalId | userId |
    +----+-----------+--------+---------------------+---------------------+------------+--------+
    |  1 | ㄹ홀      |      4 | 2022-11-01 04:33:23 | 2022-11-01 04:33:23 |     292961 |      1 |
    |  2 | ㅎㅎㅎ    |      3 | 2022-11-01 04:34:09 | 2022-11-01 04:34:09 |     292961 |      1 |
    +----+-----------+--------+---------------------+---------------------+------------+--------+
    2 rows in set (0.00 sec)
    
    mysql> select * from users where userId=1;
    ERROR 1054 (42S22): Unknown column 'userId' in 'where clause'
    mysql> select * from users;
    +----+----------------------+------------+--------------------------------------------------------------+---------------------+---------------------+---------------------+
    | id | account              | nickname   | createdAt           | updatedAt           | deletedAt           |
    +----+----------------------+------------+--------------------------------------------------------------+---------------------+---------------------+---------------------+
    |  1 | 1313@gmail.com       | dvfxvf     | 2022-10-27 04:03:34 | 2022-10-27 04:03:34 | 2022-11-15 01:24:54 |
    |  2 | 2323@gmail.com       | 닉네임2      | 2022-11-01 06:02:29 | 2022-11-15 04:06:40 | NULL                |
    ```
    
- sequelize로 콘솔을 찍어보니깐 탈퇴한 회원은 user가 null로 리턴이 되고 null이 클라이언트로 바로 넘어가니깐 에러가 나오는 에러라는 것을 파악했다.
    
    ```jsx
    [
      Reviews {
        dataValues: {
          id: 2,
          content: 'ㅎㅎㅎ',
          rating: 3,
          createdAt: 2022-11-01T04:34:09.000Z,
          updatedAt: 2022-11-01T04:34:09.000Z,
          festivalId: 292961,
          userId: 1,
          User: null
        },
        _previousDataValues: {
          id: 2,
          content: 'ㅎㅎㅎ',
          rating: 3,
          createdAt: 2022-11-01T04:34:09.000Z,
          updatedAt: 2022-11-01T04:34:09.000Z,
          festivalId: 292961,
          userId: 1,
          **User: null**
        },
        uniqno: 1,
        _changed: Set(0) {},
        _options: {
          isNewRecord: false,
          _schema: null,
          _schemaDelimiter: '',
          include: [Array],
          includeNames: [Array],
          includeMap: [Object],
          includeValidated: true,
          attributes: [Array],
          raw: true
        },
        isNewRecord: false,
        User: null
      },
      Reviews {
        dataValues: {
          id: 1,
          content: 'ㄹ홀',
          rating: 4,
          createdAt: 2022-11-01T04:33:23.000Z,
          updatedAt: 2022-11-01T04:33:23.000Z,
          festivalId: 292961,
          userId: 1,
          User: null
        },
        _previousDataValues: {
          id: 1,
          content: 'ㄹ홀',
          rating: 4,
          createdAt: 2022-11-01T04:33:23.000Z,
          updatedAt: 2022-11-01T04:33:23.000Z,
          festivalId: 292961,
          userId: 1,
          User: null
        },
        uniqno: 1,
        _changed: Set(0) {},
        _options: {
          isNewRecord: false,
          _schema: null,
          _schemaDelimiter: '',
          include: [Array],
          includeNames: [Array],
          includeMap: [Object],
          includeValidated: true,
          attributes: [Array],
          raw: true
        },
        isNewRecord: false,
        User: null
      }
    ]
    ```
    

### Solution

- User가 null일때를 분기하는 코드를 구현했다.
    
    
    ```jsx
    <li>{User.nickname}</li>
    ```
    
    ```jsx
    <li>{User ? User.nickname : '탈퇴한 회원입니다'}</li>
    ```
    
- 구현 후의 렌더링 화면
    <img src="https://user-images.githubusercontent.com/95751232/204820092-746b486f-0c21-4317-98d3-12cf13de776d.png" width="400">

