### PR TITLE
Feat_[Client, Server]: Add festival Status function in Mainpage

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -8,7 +8,7 @@
 :root {
   --primaryBlue: rgb(64 82 255);
   --primaryGreen: #60ff53;
-  --AutumnTheme: #ff9a62;
+  --primaryOrange: #ff9a62;
   --primaryPurple: #6268ff;
   --mainColor: var(--primaryPurple);
   --rem: 16;

--- a/client/src/components/Hashtag.tsx
+++ b/client/src/components/Hashtag.tsx
@@ -57,7 +57,7 @@ const Hashtag = ({ onSearch }: { onSearch: onSearchFunc }) => {
   const [curTag, setCurTag] = useState(SearchParams.get('query'));
   const tagsArr = [
     {
-      text: '가을꽃축제',
+      text: '눈꽃축제',
     },
     {
       text: '불빛축제',
@@ -65,7 +65,7 @@ const Hashtag = ({ onSearch }: { onSearch: onSearchFunc }) => {
     {
       text: '역사탐방',
     },
-    { text: '할로윈축제' },
+    { text: '크리스마스' },
   ];
 
   return (

--- a/client/src/pages/Mainpage.tsx
+++ b/client/src/pages/Mainpage.tsx
@@ -141,6 +141,7 @@ const Mainpage = ({
       );
 
       const festivals = response.data;
+      console.log(festivals);
 
       setFestivalData((prevData) => [...prevData, ...festivals]);
       setFilteredData((prevData) => [...prevData, ...festivals]);

--- a/server/controllers/festivals.js
+++ b/server/controllers/festivals.js
@@ -27,8 +27,8 @@ module.exports = {
 
     const tagsArr = [
       {
-        text: '가을꽃축제',
-        query: ['가을', '꽃', '핑크', '플라워', '국화'],
+        text: '눈꽃축제',
+        query: ['눈꽃'],
       },
       {
         text: '불빛축제',
@@ -38,7 +38,7 @@ module.exports = {
         text: '역사탐방',
         query: ['민속', '수문장', '근현대사', '화성'],
       },
-      { text: '할로윈축제', query: ['호러', '할로윈'] },
+      { text: '크리스마스', query: ['성탄', '크리스마스', '산타'] },
     ];
 
     function tagCheck(query) {
@@ -59,8 +59,8 @@ module.exports = {
             where: {
               [Op.and]: [
                 {
-                  endDate: { [Op.gte]: date },
-                  startDate: { [Op.lte]: date },
+                  // endDate: { [Op.gte]: date },
+                  // startDate: { [Op.lte]: date },
                 },
 
                 {
@@ -87,6 +87,7 @@ module.exports = {
 
             limit: Number(limit),
             offset: Number(offset),
+            order: [['endDate', 'desc']],
           });
 
           total = total.concat(festivals);
@@ -111,8 +112,8 @@ module.exports = {
           where: {
             [Op.and]: [
               {
-                endDate: { [Op.gte]: date },
-                startDate: { [Op.lte]: date },
+                // endDate: { [Op.gte]: date },
+                // startDate: { [Op.lte]: date },
               },
 
               {
@@ -139,7 +140,9 @@ module.exports = {
 
           limit: Number(limit),
           offset: Number(offset),
+          order: [['endDate', 'desc']],
         });
+        console.log(festivals.length);
 
         return res.json(festivals);
       } catch (error) {
@@ -148,14 +151,16 @@ module.exports = {
     }
 
     try {
+      // 진행중이랑 진행 예정인것 까지 나오도록
       let festivals = await Festivals.findAll({
         where: {
           endDate: { [Op.gte]: date },
-          startDate: { [Op.lte]: date },
+          // startDate: { [Op.lte]: date },
         },
 
         limit: Number(limit),
         offset: Number(offset),
+        order: [['startDate', 'asc']],
       });
       res.json(festivals);
     } catch (error) {


### PR DESCRIPTION
- 메인페이지에서 축제의 진행유무를 한눈에 알 수 있도록 하는 문구를 추가합니다.
- 공공데이터 포털에서 업데이트된 축제들을 고려하여 해시태그를 수정합니다
- 축제 데이터를 받아올 때 메인페이지에서 8개씩 받아오는 무한스크롤은 진행, 예정인 축제들만 받아오고, 검색이나 해시태그로 특정한 축제들은 종료된 축제들까지
볼 수 있도록 sequelize를 수정합니다.

# PR Type

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# requested branch

- `feat/add-festival_status` -> `dev`

# Motivation, Problem => What changed
## [Client]

- Festival 컴포넌트에 아래와 같이 Status라는 styled component를 생성해 주었다.
    
    ```jsx
    return (
        <Wrapper
          key={festivalId}
          onClick={() => {
            onClickMoveDVP(festivalId);
          }}
        >
          **<Status status={showStatus(startDate, endDate)[0]}>
            {showStatus(startDate, endDate)[1]}
          </Status>**
          <img
    ```
    
- `showStatus` 함수에 시작날과 끝나는 날 값을 넣어주면 아래와 같이 오늘의 날짜를 `20221211` 처럼 바꾸어주는 todayFunc를 호출하고 해당 값과 `startDate`, `endDate`를 비교해서 `status`라는 객체의 `scheduled`, `completed`, `inProgress`로 나눈 정보 값을 리턴해주도록 구현하였다.
    
    ```jsx
    const **todayFunc** = useCallback((): number => {
        let now = new Date();
        let year = now.getFullYear().toString();
        let month = now.getMonth() + 1;
        let convertMonth;
        let convertDate;
        let date = now.getDate();
    
        if (month < 10) {
          convertMonth = '0' + month;
        } else {
          convertMonth = month;
        }
        if (date < 10) {
          convertDate = '0' + date;
        } else {
          convertDate = date;
        }
    
        return Number(year + convertMonth + convertDate);
      }, []);
    
      const **showStatus** = useCallback((startDate: number, endDate: number) => {
        const status = {
          scheduled: '예정',
          completed: '종료',
          inProgress: '진행중',
        };
    
        const today = **todayFunc();**
    
        // 순서 중요
        if (today < startDate) {
          // 예정
          return Object.entries(status)[0];
        }
        if (today > endDate) {
          return Object.entries(status)[1];
        }
        return Object.entries(status)[2];
      }, []);
    ```
    
- Status는 props로 받아온 해당 속성에 따라서 배경색을 달리해주도록 구현하였다.
    
    ```jsx
    const Status = styled.div<{ status: string }>`
      position: absolute;
      width: 52px;
      height: 26px;
      border-radius: 0.5rem 0.1rem 0.4rem 0.1rem;
    
      background-color: ${({ status }) =>
        status === 'scheduled'
          ? `var(--primaryBlue)`
          : status === 'completed'
          ? '#4e4d4d'
          : `var(--primaryOrange)`};
      display: flex;
      justify-content: center;
      align-items: center;
      color: white;
    `;
    ```
    

## [Server]

- Mainpage에서 검색없이 해당 축제들을 무한스크롤로 불러올 때는 진행중, 예정인 축제들만 불러올 수 있도록 축제 수를 늘렸고, 검색이나 해시태그를 눌렀을 때는 종료된 축제들도 뜨게 변경하였다. 받아오는 축제들의 정렬은 진행중 ⇒ 진행 예정 ⇒ 종료 순으로 하고 싶었으나, 이건 sequelize, sql을 더 공부해봐야 될 것 같다.
- 해시태그를 눌렀을 때
    
    ```jsx
    if (isTag) {
          try {
            let total = [];
            for await (const item of isTag) {
              let festivals = await Festivals.findAll({
                where: {
                  [Op.and]: [
                    {
                      // endDate: { [Op.gte]: date },
                      // startDate: { [Op.lte]: date },
                    },
    
                    {
                      [Op.or]: [
                        {
                          title: {
                            [Op.like]: '%' + item + '%',
                          },
                        },
                        {
                          location: {
                            [Op.like]: '%' + item + '%',
                          },
                        },
                        {
                          overview: {
                            [Op.like]: '%' + item + '%',
                          },
                        },
                      ],
                    },
                  ],
                },
    
                limit: Number(limit),
                offset: Number(offset),
                order: [['endDate', 'desc']],
              });
    
              total = total.concat(festivals);
            }
    
            let filtered = total.filter((item, i) => {
              return (
                total.findIndex((item2, j) => {
                  return item.festivalId === item2.festivalId;
                }) === i
              );
            });
            return res.json(filtered);
          } catch (error) {
            console.log(error);
          }
        }
    
    ```
    
- 검색어를 입력했을 때
    
    ```jsx
    if (query) {
          try {
            let festivals = await Festivals.findAll({
              where: {
                [Op.and]: [
                  {
                    // endDate: { [Op.gte]: date },
                    // startDate: { [Op.lte]: date },
                  },
    
                  {
                    [Op.or]: [
                      {
                        title: {
                          [Op.like]: '%' + query + '%',
                        },
                      },
                      {
                        location: {
                          [Op.like]: '%' + query + '%',
                        },
                      },
                      {
                        overview: {
                          [Op.like]: '%' + query + '%',
                        },
                      },
                    ],
                  },
                ],
              },
    
              limit: Number(limit),
              offset: Number(offset),
              order: [['endDate', 'desc']],
            });
            console.log(festivals.length);
    
            return res.json(festivals);
          } catch (error) {
            console.log(error);
          }
        }
    
    ```
    
- 메인페이지에서 축제데이터를 불러올 때
    
    ```jsx
    
        
        try {
          // 진행중이랑 진행 예정인것 까지 나오도록
          let festivals = await Festivals.findAll({
            where: {
              endDate: { [Op.gte]: date },
              // startDate: { [Op.lte]: date },
            },
    
            limit: Number(limit),
            offset: Number(offset),
            order: [['startDate', 'asc']],
          });
          res.json(festivals);
        } catch (error) {
          res.status(500).send('Internal Server Error');
        }
    ```
### 시연
- 메인페이지에서 축제들을 불러올 때
  <img src="https://user-images.githubusercontent.com/95751232/208836156-c76b0610-55b1-47b9-930e-845f17a81009.gif" width=500 height=250 />
- 검색어를 입력할 때
  <img src="https://user-images.githubusercontent.com/95751232/208836543-09c56ffc-fdcf-4ff0-9999-8498e375d7a1.gif" width=500 height=250 />
- 해시태그를 클릭할 때
  <img src="https://user-images.githubusercontent.com/95751232/208836979-69a6a5e9-4b58-4974-95a8-5bc70d420155.gif" width=500 height=250 />