### PR TITLE
Feat/bugfix not disappearing searchinput

### DIFF
--- a/client/src/components/Hashtag.tsx
+++ b/client/src/components/Hashtag.tsx
@@ -54,9 +54,10 @@ const Button = styled.button<{ active: boolean }>`
 type HashtagProps = {
   onSearch: onSearchFunc;
   query: string | null;
+  setIsTag: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const Hashtag = ({ onSearch, query }: HashtagProps) => {
+const Hashtag = ({ onSearch, query, setIsTag }: HashtagProps) => {
   const [curTag, setCurTag] = useState(query);
   const tagsArr = [
     {
@@ -83,6 +84,7 @@ const Hashtag = ({ onSearch, query }: HashtagProps) => {
           onClick={() => {
             onSearch(tag.text);
             setCurTag(tag.text);
+            setIsTag(true);
           }}
           key={tag.text}
         >

--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -1,19 +1,17 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import SearchImage from '../assets/search-mobile.png';
 
-const Wrapper = styled.div`
+const Form = styled.form`
   width: 90%;
   max-width: 476px;
   height: 43px;
-
   margin-top: 0.5rem;
   background: white;
   display: flex;
   justify-content: space-evenly;
   align-items: center;
   box-shadow: 0 0.1rem 0.3rem 0.01rem lightgray;
-
   border-radius: 0.7rem;
   position: fixed;
   top: 5rem;
@@ -45,7 +43,6 @@ const Wrapper = styled.div`
   }
 
   @media (max-width: 475px) {
-    /* width: 320px; */
     border-radius: 9px;
     height: 43px;
     box-shadow: none;
@@ -60,31 +57,55 @@ const Wrapper = styled.div`
   }
 `;
 
-const Search = ({ onSearch }: { onSearch: onSearchFunc }) => {
+type onSearchProps = {
+  onSearch: onSearchFunc;
+  isTag: boolean;
+  setIsTag: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const Search = ({ onSearch, isTag, setIsTag }: onSearchProps) => {
+  /*
+  검색하다가 태그누르면 검색어가 지워저야함
+  태그가 눌러졌다는 것을 알아야함
+  태그를 누를 때는 검색어 searchText를 빈값으로 해주어야함
+  Mainpage에서 
+  isTag라는 것을 만들어서
+  태그를 클릭할 때 isTag를 true로 만들어주고
+  search는 isTag를 props로 받아서 isTag가 true면 검색창을 비워준다.
+  */
   const [searchText, setSearchText] = useState('');
 
-  const onClickSearch = () => {
-    onSearch(searchText);
-  };
-  const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchText(e.target.value);
-  };
-  const onKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
+  const onClickHandler = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
       onSearch(searchText);
+      setIsTag(false);
+    },
+    [searchText]
+  );
+  const onChangeHandler = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setSearchText(e.target.value);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (isTag) {
+      setSearchText('');
     }
-  };
+  }, [isTag]);
   return (
-    <Wrapper>
+    <Form onSubmit={onClickHandler}>
       <input
-        onKeyPress={onKeyPress}
         onChange={onChangeHandler}
         placeholder="축제를 검색해 주세요"
+        value={searchText}
       />
-      <button onClick={onClickSearch}>
+      <button type="submit">
         <img src={SearchImage} alt="search"></img>
       </button>
-    </Wrapper>
+    </Form>
   );
 };
 

--- a/client/src/pages/Mainpage.tsx
+++ b/client/src/pages/Mainpage.tsx
@@ -134,7 +134,7 @@ const Mainpage = ({
   const [hasNextPage, setHasNextPage] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [query, setQuery] = useState(searchParams.get('query'));
-
+  const [isTag, setIsTag] = useState(false);
   const navigate = useNavigate();
   const fetchData = useCallback(async () => {
     setIsLoading(true);
@@ -204,8 +204,8 @@ const Mainpage = ({
   return (
     <Wrapper>
       <SearchAndTag>
-        <Search onSearch={onSearch} />
-        <Hashtag query={query} onSearch={onSearch} />
+        <Search isTag={isTag} setIsTag={setIsTag} onSearch={onSearch} />
+        <Hashtag setIsTag={setIsTag} query={query} onSearch={onSearch} />
       </SearchAndTag>
       <FestivalList>
         {filteredData.length > 0 &&


### PR DESCRIPTION
# PR Type

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# requested branch

- `feat/bugfix-not-disappearing-searchinput` -> `dev`

# Problem ⇒ What changed

## 문제

- 이전 작업인 [태그 눌러보고 검색할 때 태그 흔적 사라지지 않는 에러](https://www.notion.so/d6a3442aa1e24c2cae415f99673db12e) 머지하고 나서 생각이 났다. 검색어를 입력 한 후에 해시태그를 누르면 검색창에 검색어가 계속 남아있어서 유저가 보기에 검색창의 검색어와 해시태그가 같이 적용된 것 같은 착각이 들 수 있다.
  <img src="https://user-images.githubusercontent.com/95751232/209916318-eb476c8e-d3ea-4758-a5b0-c678671d7faf.gif" width=500 />


    

## 원인

- 기존의 `<Hashtag />` 같이, 검색어를 입력 후에 다른 컴포넌트에서 변화가 일어날 시(ex. 해시태그를 누를 때) 이를 반영해주는 로직이 없기 때문에 검색창의 검색어상태는 계속 유지되고 있다.
    
    ```tsx
    const Search = ({ onSearch }: { onSearch: onSearchFunc }) => {
      const [searchText, setSearchText] = useState('');
    
      const onClickSearch = () => {
        onSearch(searchText);
      };
      const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
        setSearchText(e.target.value);
      };
      const onKeyPress = (e: React.KeyboardEvent) => {
        if (e.key === 'Enter') {
          onSearch(searchText);
        }
      };
      return (
        <Wrapper>
          <input
            onKeyPress={onKeyPress}
            onChange={onChangeHandler}
            placeholder="축제를 검색해 주세요"
          />
          <button onClick={onClickSearch}>
            <img src={SearchImage} alt="search"></img>
          </button>
        </Wrapper>
      );
    };
    
    export default Search;
    ```
    

## 해결방안

- 해시태그를 누를 때 검색창에 검색어가 있다면 비워줘야 한다.
- 그러려면  `<Hashtag />`가 사용중인 것을 `<Search />`가 알아야 인지를 해야한다.
- 두 컴포넌트 모두 `<Mainpage />`의 자식 컴포넌트이기 때문에 `<Mainpage />` 에서 해시태그를 눌렀는지 여부와 그 여부를 세팅하는 상태관리 함수를 만들어주고 이를 `props`로 `<Hashtag />` 와 `<Search />`에 알려주면 된다.

### 코드와 함께 로직 설명

1. `<Mainpage />`에서 해시태그를 눌렀는지 아닌지를 `isTag`로 `boolean`으로 판단하는 `useState`를 만들어준다.
    
    ```tsx
    const Mainpage = ({}: MainpageProps) => {
    		~~
      const [isTag, setIsTag] = useState(false);
    return (
        <Wrapper>
          <SearchAndTag>
            <Search isTag={isTag} setIsTag={setIsTag} onSearch={onSearch} /> // --- (3)
            <Hashtag setIsTag={setIsTag} query={query} onSearch={onSearch} /> // --- (2)
          </SearchAndTag>
    ~~~
    ```
    
    - `<Search />`와 `<Hashtag />` 에 `props`로 `isTag`, `setIsTag`를 넘겨준다.
2. 해시태그를 클릭할 때 `setIsTag`를 `true`로 하여 `isTag`의 상태를 바꾸어준다.
    
    ```tsx
    const Hashtag = ({ onSearch, query, setIsTag }: HashtagProps) => {
    
    ~~
      return (
        <Wrapper>
          {tagsArr.map((tag) => (
            <Button
              active={curTag === tag.text}
              onClick={() => {
                onSearch(tag.text);
                setCurTag(tag.text);
                setIsTag(true);
              }}
              key={tag.text}
            >
              #{tag.text}
            </Button>
          ))}
        </Wrapper>
      );
    };
    
    export default Hashtag;
    ```
    
3. 검색창을 이용해서 검색버튼을 누르면 `setIsTag(false)`로 태그를 누르지 않았다고 상태변경을 해준다. 해시태그를 눌렀다면 `isTag`의 상태가 `true`로 변할거고, `props`로 받아오는 `isTag`를 `useEffect`를 통해서 업데이트해준 다음에 태그를 사용했다는 것을 인지하면 (`isTag === true`) 검색창을 빈값으로 바꾸어 준다.
    
    ```tsx
    const Search = ({ onSearch, isTag, setIsTag }: onSearchProps) => {
      const [searchText, setSearchText] = useState('');
    
      const onClickHandler = useCallback(
        (e: React.FormEvent<HTMLFormElement>) => {
          e.preventDefault();
          onSearch(searchText);
          setIsTag(false); // --- 검색창을 이용할 때는 isTag를 false로 바꾸기
        },
        [searchText]
      );
      const onChangeHandler = useCallback(
        (e: React.ChangeEvent<HTMLInputElement>) => {
          setSearchText(e.target.value);
        },
        []
      );
    
      useEffect(() => {
        if (isTag) {
          setSearchText(''); // --- props로 받아온 isTag의 상태가 바뀌어 true면 빈값처리해주기
        }
      }, [isTag]);
      return (
        <Form onSubmit={onClickHandler}>
          <input
            onChange={onChangeHandler}
            placeholder="축제를 검색해 주세요"
            value={searchText}
          />
          <button type="submit">
            <img src={SearchImage} alt="search"></img>
          </button>
        </Form>
      );
    };
    
    export default Search;
    ```
    

### 그밖에..리팩토링?

- `onkeydown`이 `deprecated`되었다는 경고가 떠서 이전에 인풋창에서 엔터를 누를 때, 검색버튼을 누를 때 각각 검색함수를 실행시켜준 것을 `form`으로 대체하여 한 큐에 검색되도록 리팩토링하였따.
    
    ```tsx
    const onClickHandler = useCallback(
        (e: React.FormEvent<HTMLFormElement>) => {
          e.preventDefault();
          onSearch(searchText);
          setIsTag(false);
        },
        [searchText]
      );
    
    return (
        <Form onSubmit={onClickHandler}>
          <input
            onChange={onChangeHandler}
            placeholder="축제를 검색해 주세요"
            value={searchText}
          />
          <button type="submit">
            <img src={SearchImage} alt="search"></img>
          </button>
        </Form>
      );
    ```
    

## 시연
<img src="https://user-images.githubusercontent.com/95751232/209916189-13628a99-2a4d-4a3a-ae54-112baf53df06.gif" width=500  >


