### PR TITLE
Feat_[Client]: Add modal transition CSS in Login

### DIFF
--- a/client/declaration.d.ts
+++ b/client/declaration.d.ts
@@ -73,8 +73,8 @@ type Summary = {
 };
 
 type ModalContext = {
-  openLoginModal: boolean;
-  setLoginModal: React.Dispatch<React.SetStateAction<boolean>>;
+  isLoginModal: boolean;
+  setIsLoginModal: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 type UserContext = {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -101,3 +101,46 @@ input:focus {
     transform: rotate(1turn);
   }
 }
+
+@keyframes slide-down {
+  from {
+    transform: translateY(-1rem);
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0rem);
+  }
+}
+
+@keyframes slide-up {
+  from {
+    transform: translateY(0rem);
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(-1rem);
+  }
+}
+
+@keyframes dark-soft {
+  from {
+    background: none;
+  }
+
+  to {
+    background: rgba(0, 0, 0, 0.4);
+  }
+}
+@keyframes bright-soft {
+  from {
+    background: rgba(0, 0, 0, 0.4);
+  }
+
+  to {
+    background: none;
+  }
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,8 +14,7 @@ import Main from './pages/Main';
 import Account from './pages/Account';
 import Header from './components/Header';
 import Footer from './components/Footer';
-import LoginModal from './components/LoginModal';
-import SignupModal from './components/SignupModal';
+import Login from './components/Login';
 
 const Wrapper = styled.div`
   width: 100%;
@@ -61,8 +60,7 @@ function App() {
   );
   const [filteredData, setFilteredData] =
     useState<FestivalItem[]>(festivalData);
-  const [openLoginModal, setLoginModal] = useState(false);
-  const [openSignupModal, setSignupModal] = useState(false);
+  const [isLoginModal, setIsLoginModal] = useState(false);
   const offset = useRef(0);
 
   const loginHandler: loginHandlerFunc = useCallback(
@@ -152,87 +150,26 @@ function App() {
     nextAuthState.nickname = nickname;
     setAuthState(nextAuthState);
   };
-  // const refreshData = async () => {
-  //   if (sessionStorage.getItem('accesstoken')) {
-  //     const authData = await axios.get(
-  //       `${process.env.REACT_APP_SERVER_URL}/users`,
-  //       {
-  //         headers: {
-  //           accesstoken: sessionStorage.getItem('accesstoken') ?? '',
-  //         },
-  //       }
-  //     );
-
-  //     const { userId, account, nickname, defaultPic } = authData.data.info;
-  //     const user: { [index: string]: number | boolean | string } = {
-  //       userId,
-  //       account,
-  //       nickname,
-  //       defaultPic,
-  //       loginStatus: true,
-  //     };
-  //     if (sessionStorage.getItem('user')) {
-  //       const storageUser = sessionStorage.getItem('user');
-
-  //       if (storageUser) {
-  //         const parsedUser = JSON.parse(storageUser);
-  //         for (const key in user) {
-  //           console.log(user[key], parsedUser[key]);
-  //           if (user[key] !== parsedUser[key]) {
-  //             break;
-  //           }
-  //         }
-  //         return;
-  //       }
-  //     }
-  //     console.log('업데이트간다');
-
-  //     setAuthState({
-  //       userId,
-  //       account,
-  //       nickname,
-  //       defaultPic,
-  //       loginStatus: true,
-  //     });
-
-  //     const pickedItems = await axios.get(
-  //       `${process.env.REACT_APP_SERVER_URL}/pick`,
-  //       {
-  //         headers: {
-  //           accesstoken: sessionStorage.getItem('accesstoken') ?? '',
-  //         },
-  //       }
-  //     );
-  //     setPickItems(pickedItems.data);
-  //   }
-  // };
 
   return (
     <ThemeProvider theme={theme}>
-      <ModalContext.Provider value={{ openLoginModal, setLoginModal }}>
+      <ModalContext.Provider value={{ isLoginModal, setIsLoginModal }}>
         <UserContext.Provider value={{ authState, setAuthState }}>
           <Wrapper>
             <Helmet>
               <title>이번주엔 어디로 가볼까? - LOCO</title>
             </Helmet>
-            {openLoginModal && (
-              <LoginModal
+            {isLoginModal && (
+              <Login
                 loginHandler={loginHandler}
-                setLoginModal={setLoginModal}
-                setSignupModal={setSignupModal}
-              />
-            )}
-            {openSignupModal && (
-              <SignupModal
-                setSignupModal={setSignupModal}
-                setLoginModal={setLoginModal}
+                setIsLoginModal={setIsLoginModal}
               />
             )}
 
             <Header
               authState={authState}
               setAuthState={setAuthState}
-              setLoginModal={setLoginModal}
+              setIsLoginModal={setIsLoginModal}
             />
             <Routes>
               <Route
@@ -284,7 +221,7 @@ function App() {
                 }
               ></Route>
             </Routes>
-            <Footer authState={authState} setLoginModal={setLoginModal} />
+            <Footer authState={authState} setIsLoginModal={setIsLoginModal} />
           </Wrapper>
         </UserContext.Provider>
       </ModalContext.Provider>

--- a/client/src/components/Festival.tsx
+++ b/client/src/components/Festival.tsx
@@ -229,7 +229,7 @@ const Festival = ({ festival, togglePick, pickItems }: FestivalProps) => {
               } else {
                 e.stopPropagation();
                 if (modalContext) {
-                  modalContext.setLoginModal(true);
+                  modalContext.setIsLoginModal(true);
                 }
               }
             }

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -69,17 +69,17 @@ const Item = styled.div`
 
 type FooterProps = {
   authState: AuthState;
-  setLoginModal: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsLoginModal: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const Footer = ({ authState, setLoginModal }: FooterProps) => {
+const Footer = ({ authState, setIsLoginModal }: FooterProps) => {
   let navigate = useNavigate();
   const goPage = useCallback(
     (path: string) => {
       if (authState.loginStatus) {
         navigate(`/${path}`);
       } else {
-        setLoginModal(true);
+        setIsLoginModal(true);
       }
     },
     [authState]

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -31,10 +31,10 @@ const Wrapper = styled.header`
 type HeaderProps = {
   authState: AuthState;
   setAuthState: React.Dispatch<React.SetStateAction<AuthState>>;
-  setLoginModal: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsLoginModal: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const Header = ({ authState, setLoginModal, setAuthState }: HeaderProps) => {
+const Header = ({ authState, setIsLoginModal, setAuthState }: HeaderProps) => {
   const onClickReload = () => {
     window.location.replace('/');
   };
@@ -43,7 +43,7 @@ const Header = ({ authState, setLoginModal, setAuthState }: HeaderProps) => {
     <Wrapper>
       <h1 onClick={onClickReload}>LoCo</h1>
       <Navigationbar
-        setLoginModal={setLoginModal}
+        setIsLoginModal={setIsLoginModal}
         authState={authState}
         setAuthState={setAuthState}
       />

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -1,8 +1,9 @@
 import axios from 'axios';
 import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
+import Signup from './Signup';
 
-const ModalBackdrop = styled.div`
+const Backdrop = styled.div<{ isHide: boolean }>`
   z-index: 20;
   position: fixed;
   left: 0;
@@ -10,8 +11,12 @@ const ModalBackdrop = styled.div`
   width: 100%;
   height: 100vh;
   background: rgba(0, 0, 0, 0.4);
+
+  animation-duration: 0.4s;
+  animation-name: ${(props) => (props.isHide ? 'bright-soft' : 'dark-soft')};
+  animation-fill-mode: forwards;
 `;
-const ModalContainer = styled.div`
+const Container = styled.div<{ isHide: boolean }>`
   z-index: 100;
   position: fixed;
   width: 400px;
@@ -27,6 +32,10 @@ const ModalContainer = styled.div`
   margin-left: -200px;
   left: 50%;
   top: 50%;
+
+  animation-duration: 0.4s;
+  animation-name: ${(props) => (props.isHide ? 'slide-up' : 'slide-down')};
+  animation-fill-mode: forwards;
 
   & > h1 {
     margin: 2rem 0;
@@ -126,20 +135,24 @@ const ModalContainer = styled.div`
   }
 `;
 
-type LoginModalProps = {
-  setLoginModal: React.Dispatch<React.SetStateAction<boolean>>;
-  setSignupModal: React.Dispatch<React.SetStateAction<boolean>>;
+/*
+백드롭은 계속 어둡게 하고 
+로그인  => 회원가입 => 성공 => 실패
+
+*/
+
+type LoginProps = {
+  setIsLoginModal: React.Dispatch<React.SetStateAction<boolean>>;
   loginHandler: loginHandlerFunc;
 };
 
-const LoginModal = ({
-  setLoginModal,
-  setSignupModal,
-  loginHandler,
-}: LoginModalProps) => {
+const Login = ({ setIsLoginModal, loginHandler }: LoginProps) => {
   const [userInfo, setUserInfo] = useState({ account: '', password: '' });
   const { account, password } = userInfo;
   const [errMessage, setErrMessage] = useState('');
+  const [isHide, setIsHide] = useState(false);
+  const [isLogin, setIsLogin] = useState(true);
+  const [isSignup, setIsSignup] = useState(false);
 
   const errMessages = [
     '사용자가 존재하지 않습니다',
@@ -199,59 +212,76 @@ const LoginModal = ({
     [account, password]
   );
   const modalClose = () => {
-    setLoginModal(false);
+    setIsHide(true);
+    setIsSignup(false);
+    setTimeout(() => {
+      setIsLoginModal(false);
+    }, 400);
   };
   return (
     <>
-      <ModalBackdrop onClick={modalClose} />
-      <ModalContainer>
-        <h1>Loco</h1>
-        <form onSubmit={handleSubmit}>
-          <input
-            name="account"
-            placeholder="email을 입력해 주세요"
-            onChange={handleUserInfo}
-            type="text"
-            value={account}
-            required
-          ></input>
-          <div>{errMessage === '사용자가 존재하지 않습니다' && errMessage}</div>
-          <input
-            name="password"
-            placeholder="비밀번호를 입력해 주세요"
-            onChange={handleUserInfo}
-            type="password"
-            value={password}
-            required
-          ></input>
-          <div>
-            {errMessage === '비밀번호가 일치하지 않습니다' && errMessage}
-          </div>
-          <button type="submit">로그인</button>
-        </form>
-        <div className="footer">
-          {/* <button>비밀번호 재설정</button> */}
-          <span>아직 계정이 없으신가요?</span>
-          <button
-            onClick={() => {
-              setLoginModal(false);
-              setSignupModal(true);
+      <Backdrop onClick={modalClose} isHide={isHide}>
+        {isLogin && (
+          <Container
+            isHide={isHide}
+            onClick={(e) => {
+              e.stopPropagation();
             }}
           >
-            회원가입
-          </button>
-        </div>
-        <button
-          className="modalClose"
-          onClick={() => {
-            setLoginModal(false);
-          }}
-        >
-          돌아가기
-        </button>
-      </ModalContainer>
+            <h1>Loco</h1>
+            <form onSubmit={handleSubmit}>
+              <input
+                name="account"
+                placeholder="email을 입력해 주세요"
+                onChange={handleUserInfo}
+                type="text"
+                value={account}
+                required
+              ></input>
+              <div>
+                {errMessage === '사용자가 존재하지 않습니다' && errMessage}
+              </div>
+              <input
+                name="password"
+                placeholder="비밀번호를 입력해 주세요"
+                onChange={handleUserInfo}
+                type="password"
+                value={password}
+                required
+              ></input>
+              <div>
+                {errMessage === '비밀번호가 일치하지 않습니다' && errMessage}
+              </div>
+              <button type="submit">로그인</button>
+            </form>
+            <div className="footer">
+              <span>아직 계정이 없으신가요?</span>
+              <button
+                onClick={() => {
+                  setIsLogin(false);
+                  setIsSignup(true);
+                }}
+              >
+                회원가입
+              </button>
+            </div>
+            <button
+              className="modalClose"
+              onClick={() => {
+                setIsLoginModal(false);
+              }}
+            >
+              돌아가기
+            </button>
+          </Container>
+        )}
+
+        {isSignup && (
+          <Signup setIsSignup={setIsSignup} setIsLogin={setIsLogin} />
+        )}
+      </Backdrop>
     </>
   );
 };
 
-export default LoginModal;
+export default Login;

--- a/client/src/components/Navigationbar.tsx
+++ b/client/src/components/Navigationbar.tsx
@@ -7,13 +7,10 @@ import { CgProfile } from 'react-icons/cg';
 import { memo } from 'react';
 
 const Container = styled.section`
-  /* width: 30%; */
   height: 100%;
   display: flex;
-  /* background-color: yellow; */
 
   .message {
-    /* background-color: aliceblue; */
     display: flex;
     justify-content: center;
     align-items: center;
@@ -25,13 +22,10 @@ const Container = styled.section`
 
 const ButtonsWrapper = styled.div<{ isLogin: boolean; isPic: string }>`
   display: flex;
-  /* width: 100%; */
   height: 100%;
   z-index: 30;
   justify-content: center;
   align-items: center;
-  /* position: relative; */
-  /* background-color: white; */
   overflow: hidden;
   padding: 0.5rem;
   button {
@@ -58,15 +52,6 @@ const ButtonsWrapper = styled.div<{ isLogin: boolean; isPic: string }>`
       min-height: 1.5rem;
       color: var(--primaryPurple);
     }
-    /* ${(props) =>
-      props.isLogin === false &&
-      css`
-        background-color: transparent;
-        height: 100%;
-        padding: 0.5rem 1rem;
-        color: var(--primaryBlue);
-        font-weight: 500;
-      `} */
   }
 
   ${(props) =>
@@ -131,12 +116,12 @@ const ItemsWrapper = styled.ul`
 type NavigationbarProps = {
   authState: AuthState;
   setAuthState: React.Dispatch<React.SetStateAction<AuthState>>;
-  setLoginModal: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsLoginModal: React.Dispatch<React.SetStateAction<boolean>>;
 };
 const Navigationbar = ({
   authState,
   setAuthState,
-  setLoginModal,
+  setIsLoginModal,
 }: NavigationbarProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -194,7 +179,7 @@ const Navigationbar = ({
       >
         <button
           onClick={() => {
-            !authState.loginStatus && setLoginModal(true);
+            !authState.loginStatus && setIsLoginModal(true);
           }}
         >
           {authState.loginStatus ? (

--- a/client/src/components/Signup.tsx
+++ b/client/src/components/Signup.tsx
@@ -6,17 +6,7 @@ import { ReactComponent as ServerFail } from '../assets/server-fail.svg';
 import Loading, { Wrapper as W } from './Loading';
 import { useEffect } from 'react';
 
-const ModalBackdrop = styled.div`
-  position: fixed;
-  z-index: 20;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100vh;
-  background-color: rgba(0, 0, 0, 0.4);
-`;
-
-const ModalContainer = styled.div`
+const ModalContainer = styled.div<{ isHide: boolean }>`
   z-index: 100;
   position: fixed;
   top: 0;
@@ -33,6 +23,10 @@ const ModalContainer = styled.div`
   border-radius: 10px;
   background-color: white;
   padding: 1rem;
+
+  animation-duration: 0.4s;
+  animation-name: ${(props) => (props.isHide ? 'slide-up' : 'slide-down')};
+  animation-fill-mode: forwards;
 
   h1 {
     font-size: 3rem;
@@ -233,7 +227,6 @@ export const ShowValid = styled.div<{
   isUnique?: boolean;
 }>`
   font-size: 0.8rem;
-  /* height: 0.8rem; */
   font-weight: bold;
   font-family: 'NanumSquareRound';
   word-break: normal;
@@ -252,8 +245,8 @@ export const ShowValid = styled.div<{
 `;
 
 type SignupModalProps = {
-  setSignupModal: React.Dispatch<React.SetStateAction<boolean>>;
-  setLoginModal: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsSignup: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsLogin: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 type Message = {
@@ -331,15 +324,12 @@ export function validate(
   if (rgx[type]) {
     return rgx[type].test(value) ? true : false;
   } else {
-    /* 계정페이지에서 현재 비밀번호와 같다면 해줄 필요 없으니깐 
-    account에서 이전비밀번호가 인자로 들어오면 이전번호와 같을 때 false
-    해당 */
     return password === value ? true : false;
   }
 }
 export type Progress = 'inProgress' | 'success' | 'failed';
 
-const SignupModal = ({ setSignupModal, setLoginModal }: SignupModalProps) => {
+const Signup = ({ setIsSignup, setIsLogin }: SignupModalProps) => {
   const [userInfo, setUserInfo] = useState<userInfo>({
     account: { text: '', isValid: false, isUnique: false },
     nickname: { text: '', isValid: false, isUnique: false },
@@ -354,6 +344,7 @@ const SignupModal = ({ setSignupModal, setLoginModal }: SignupModalProps) => {
   });
   const [isLoading, setLoading] = useState(false);
   const [progress, setProgress] = useState<Progress>('inProgress');
+  const [isHide, setIsHide] = useState(false);
   const { account, nickname, password, passwordCheck } = userInfo;
 
   const handleUserInfo = useCallback(
@@ -519,19 +510,8 @@ const SignupModal = ({ setSignupModal, setLoginModal }: SignupModalProps) => {
     }
   };
 
-  /*
-  회원가입 버튼 눌러서 유효성, 중복 다 통과하면 로딩 나오면서 서버로 보내기
-  서버에서 받아오면 isLoading false로 해주면서 끝 
-
-  회원가입 진행중이면 inProgress
-  회원가입 성공이면   completed
-  회원가입 실패면     failed
-  
-  */
-
   const Success = () => {
     const [count, setCount] = useState(3);
-    console.log(count);
 
     useEffect(() => {
       const timer = setInterval(() => {
@@ -539,8 +519,8 @@ const SignupModal = ({ setSignupModal, setLoginModal }: SignupModalProps) => {
       }, 1000);
 
       let closeModal = setTimeout(() => {
-        setSignupModal(false);
-        setLoginModal(true);
+        setIsSignup(false);
+        setIsLogin(true);
       }, 4000);
       return () => {
         clearInterval(timer);
@@ -571,154 +551,151 @@ const SignupModal = ({ setSignupModal, setLoginModal }: SignupModalProps) => {
   };
 
   return (
-    <>
-      <ModalBackdrop
-        onClick={() => {
-          setSignupModal(false);
-        }}
-      />
-      <ModalContainer
-        onClick={(e) => {
-          e.stopPropagation();
-        }}
-      >
-        {isLoading && (
-          <LoadingWrapper>
-            <h1>Loco</h1>
-            <Loading text={'Loading'} />
-          </LoadingWrapper>
-        )}
-        {!isLoading && progress === 'inProgress' ? (
-          <div className="signupForm">
-            <h1>LoCo</h1>
-            <form>
-              <div className="validInfo">
-                <label htmlFor="account">이메일 주소</label>{' '}
-                <ShowValid
-                  checkType={'account'}
-                  isValid={account.isValid}
-                  isUnique={account.isUnique}
-                >
-                  {validMsg.account}
-                </ShowValid>
-                <button
-                  name="account"
-                  onClick={duplicateCheck}
-                  disabled={!account.isValid || account.isUnique}
-                >
-                  중복 확인
-                </button>
-              </div>
-              <input
-                name="account"
-                type="text"
-                value={account.text}
-                required
-                onChange={handleUserInfo}
-              />
-              <div className="validInfo">
-                <label htmlFor="nickname">닉네임</label>
-                <ShowValid
-                  checkType={'nickname'}
-                  isValid={nickname.isValid}
-                  isUnique={nickname.isUnique}
-                >
-                  {validMsg.nickname}
-                </ShowValid>
-                <button
-                  name="nickname"
-                  onClick={duplicateCheck}
-                  disabled={!nickname.isValid || nickname.isUnique}
-                >
-                  중복 확인
-                </button>
-              </div>
-              <input
-                name="nickname"
-                type="text"
-                value={nickname.text}
-                required
-                onChange={handleUserInfo}
-              />
-              <div className="validInfo">
-                <label htmlFor="password">비밀번호</label>{' '}
-                <ShowValid checkType="password" isValid={password.isValid}>
-                  {validMsg.password}
-                </ShowValid>
-              </div>
-              <input
-                name="password"
-                type="password"
-                value={password.text}
-                required
-                onChange={handleUserInfo}
-              />
-              <div className="validInfo">
-                <label htmlFor="passwordCheck">비밀번호 확인</label>
-                <ShowValid
-                  checkType="passwordCheck"
-                  isValid={passwordCheck.isValid}
-                >
-                  {validMsg.passwordCheck}
-                </ShowValid>
-              </div>
-              <input
-                name="passwordCheck"
-                type="password"
-                value={passwordCheck.text}
-                required
-                onChange={handleUserInfo}
-              />
-              <button onClick={handleSubmit}>회원가입</button>
-            </form>
-
-            <LoginSection>
-              <p>이미 계정이 있으신가요?</p>
-              <button
-                onClick={() => {
-                  setSignupModal(false);
-                  setLoginModal(true);
-                }}
+    <ModalContainer
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
+      isHide={isHide}
+    >
+      {isLoading && (
+        <LoadingWrapper>
+          <h1>Loco</h1>
+          <Loading text={'Loading'} />
+        </LoadingWrapper>
+      )}
+      {!isLoading && progress === 'inProgress' ? (
+        <div className="signupForm">
+          <h1>LoCo</h1>
+          <form>
+            <div className="validInfo">
+              <label htmlFor="account">이메일 주소</label>{' '}
+              <ShowValid
+                checkType={'account'}
+                isValid={account.isValid}
+                isUnique={account.isUnique}
               >
-                로그인
+                {validMsg.account}
+              </ShowValid>
+              <button
+                name="account"
+                onClick={duplicateCheck}
+                disabled={!account.isValid || account.isUnique}
+              >
+                중복 확인
               </button>
-            </LoginSection>
-            <button
-              className="modalClose"
-              onClick={() => {
-                setSignupModal(false);
-              }}
-            >
-              돌아가기
-            </button>
-          </div>
-        ) : !isLoading && progress === 'success' ? (
-          <Success />
-        ) : !isLoading && progress === 'failed' ? (
-          <div className="errMessage">
-            <h1>
-              Let's{' '}
-              <span style={{ color: 'var(--primaryOrange)', fontSize: '5rem' }}>
-                LoCo
-              </span>
-            </h1>
-            <ServerFail />
-            <div>
-              <p>서버와의 연결이 끊어졌습니다</p>
-              <p>잠시 후에 다시 시도해 주세요</p>
             </div>
+            <input
+              name="account"
+              type="text"
+              value={account.text}
+              required
+              onChange={handleUserInfo}
+            />
+            <div className="validInfo">
+              <label htmlFor="nickname">닉네임</label>
+              <ShowValid
+                checkType={'nickname'}
+                isValid={nickname.isValid}
+                isUnique={nickname.isUnique}
+              >
+                {validMsg.nickname}
+              </ShowValid>
+              <button
+                name="nickname"
+                onClick={duplicateCheck}
+                disabled={!nickname.isValid || nickname.isUnique}
+              >
+                중복 확인
+              </button>
+            </div>
+            <input
+              name="nickname"
+              type="text"
+              value={nickname.text}
+              required
+              onChange={handleUserInfo}
+            />
+            <div className="validInfo">
+              <label htmlFor="password">비밀번호</label>{' '}
+              <ShowValid checkType="password" isValid={password.isValid}>
+                {validMsg.password}
+              </ShowValid>
+            </div>
+            <input
+              name="password"
+              type="password"
+              value={password.text}
+              required
+              onChange={handleUserInfo}
+            />
+            <div className="validInfo">
+              <label htmlFor="passwordCheck">비밀번호 확인</label>
+              <ShowValid
+                checkType="passwordCheck"
+                isValid={passwordCheck.isValid}
+              >
+                {validMsg.passwordCheck}
+              </ShowValid>
+            </div>
+            <input
+              name="passwordCheck"
+              type="password"
+              value={passwordCheck.text}
+              required
+              onChange={handleUserInfo}
+            />
+            <button onClick={handleSubmit}>회원가입</button>
+          </form>
+
+          <LoginSection>
+            <p>이미 계정이 있으신가요?</p>
             <button
               onClick={() => {
-                setSignupModal(false);
+                setIsHide(true);
+                setTimeout(() => {
+                  setIsSignup(false);
+                  setIsLogin(true);
+                }, 150);
               }}
             >
-              메인페이지로 돌아가기
+              로그인
             </button>
+          </LoginSection>
+          <button
+            className="modalClose"
+            onClick={() => {
+              setIsSignup(false);
+            }}
+          >
+            돌아가기
+          </button>
+        </div>
+      ) : !isLoading && progress === 'success' ? (
+        <Success />
+      ) : !isLoading && progress === 'failed' ? (
+        <div className="errMessage">
+          <h1>
+            Let's{' '}
+            <span style={{ color: 'var(--primaryOrange)', fontSize: '5rem' }}>
+              LoCo
+            </span>
+          </h1>
+          <ServerFail />
+          <div>
+            <p>서버와의 연결이 끊어졌습니다</p>
+            <p>잠시 후에 다시 시도해 주세요</p>
           </div>
-        ) : null}
-      </ModalContainer>
-    </>
+          <button
+            onClick={() => {
+              setIsSignup(false);
+            }}
+          >
+            메인페이지로 돌아가기
+          </button>
+        </div>
+      ) : null}
+    </ModalContainer>
   );
 };
 
-export default SignupModal;
+export default Signup;

--- a/client/src/components/reviews/ReviewWrite.tsx
+++ b/client/src/components/reviews/ReviewWrite.tsx
@@ -370,7 +370,7 @@ const ReviewWrite = ({
             <Button
               onClick={() => {
                 if (modalContext) {
-                  modalContext.setLoginModal(true);
+                  modalContext.setIsLoginModal(true);
                 }
               }}
             >

--- a/client/src/contexts/modalContext.ts
+++ b/client/src/contexts/modalContext.ts
@@ -3,5 +3,5 @@ import { createContext } from 'react';
 export const ModalContext = createContext<ModalContext | null>(null);
 
 export const induceLogin = (modalContext: ModalContext | null) => {
-  modalContext && modalContext.setLoginModal(true);
+  modalContext && modalContext.setIsLoginModal(true);
 };

--- a/client/src/pages/Account.tsx
+++ b/client/src/pages/Account.tsx
@@ -17,7 +17,7 @@ import {
   message,
   ShowValid,
   Progress,
-} from '../components/SignupModal';
+} from '../components/Signup';
 
 import { ReactComponent as Confirm } from '../assets/confirm.svg';
 import { ReactComponent as Fail } from '../assets/server-fail.svg';

--- a/client/src/pages/DetailView.tsx
+++ b/client/src/pages/DetailView.tsx
@@ -595,7 +595,7 @@ const DetailView = ({ togglePick, authState }: DetailViewProps) => {
                   } else {
                     e.stopPropagation();
                     if (modalContext) {
-                      modalContext.setLoginModal(true);
+                      modalContext.setIsLoginModal(true);
                     }
                   }
                 }}
@@ -701,7 +701,7 @@ const DetailView = ({ togglePick, authState }: DetailViewProps) => {
                 } else {
                   e.stopPropagation();
                   if (modalContext) {
-                    modalContext.setLoginModal(true);
+                    modalContext.setIsLoginModal(true);
                   }
                 }
               }}


### PR DESCRIPTION
- 로그인, 회원가입 모달 마운트시, 부드럽게 나타나도록 구현합니다.

[Refactor]
- 로그인 모달을 띄운 후, 회원가입 모달과 로그인 모달을 왔다갔다 할때, 트랜지션 효과가 중첩되어 부자연 스러운 UX가 나타나므로,
로그인모달의 Backdrop에서 로그인모달과, 회원가입모달이 (un)mount 되도록
구조를 변경합니다.
- 로그인 모달 컴포넌트와 그 안의 컨테이너 컴포넌트간의 변수명 혼란을 줄이기 위해, LoginModal => Login, SignupModal => Signup 으로 컴포넌트명을 변경합니다.

# PR Type

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# requested branch

- `feat/add-modal-transition` -> `dev`

# Motivation, Problem
- 기존 로그인 모달과 회원가입 모달이 마운트 될때 좀더 부드럽게 나타나기 위해 animation 효과를 주었다.
- 모달 뒷배경에 적용할 애니메이션
    
    ```css
    
    @keyframes dark-soft {
      from {
        background: none;
      }
    
      to {
        background: rgba(0, 0, 0, 0.4);
      }
    }
    @keyframes bright-soft {
      from {
        background: rgba(0, 0, 0, 0.4);
      }
    
      to {
        background: none;
      }
    }
    ```
    
- 모달 컨테이너에 적용할 애니메이션
    
    ```css
    @keyframes slide-down {
      from {
        transform: translateY(-1rem);
        opacity: 0;
      }
    
      to {
        opacity: 1;
        transform: translateY(0rem);
      }
    }
    
    @keyframes slide-up {
      from {
        transform: translateY(0rem);
        opacity: 1;
      }
    
      to {
        opacity: 0;
        transform: translateY(-1rem);
      }
    }
    ```
    
- 로그인 , 회원가입 모달이 등장할 때  아래와 같이 뒷배경에는 ‘dark-soft’ 애니메이션이 작동하여 서서히 어두워지게 된다.
- 컨테이너는 등장할 때는 ‘slide-down’ 애니메이션이 작동하여 위에서 아래로 내려오도록 구현하였다.
- 1. 뒷배경을 클릭하는 경우, 2. 로그인 ⇒ 회원가입, 3. 회원가입 ⇒ 로그인 으로 이동할 때 사라지는 모달이 있는데 이때 `isHide`라는 상태를  `true` 로 업데이트 한 후,  `props`로 넘겨주고 styled-component를 활용하여 `isHide`가 `true`일때 (모달이 사라질 때) 적용할 애니메이션이 작동되도록 한다.
    
    ```tsx
    const Backdrop = styled.div<{ isHide: boolean }>`
      ~~
      animation-duration: 0.4s;
      animation-name: ${(props) => (props.isHide ? 'bright-soft' : 'dark-soft')};
      animation-fill-mode: forwards;
    `;
    const Container = styled.div<{ isHide: boolean }>`
    ~~
      animation-duration: 0.4s;
      animation-name: ${(props) => (props.isHide ? 'slide-up' : 'slide-down')};
      animation-fill-mode: forwards;
    `;
    ```
    
    ```tsx
    const modalClose = () => { // 모달이 닫힐 때 
        setIsHide(true);
        setIsSignup(false);
        setTimeout(() => {
          setIsLoginModal(false);
        }, 400);
      };
    ~~
    <Backdrop onClick={modalClose} isHide={isHide}>
            {isLogin && (
              <Container isHide={isHide}>
                <h1>Loco</h1>
                <form onSubmit={handleSubmit}/>
                <div className="footer">
                  <span>아직 계정이 없으신가요?</span>
                  <button
                    onClick={() => {
                      setIsLogin(false);
                      setIsSignup(true);
                    }}
                  >
                    회원가입
                  </button>
                </div>
                <button
                  className="modalClose"
                  onClick={() => {
                    setIsLoginModal(false);
                  }}
                >
                  돌아가기
                </button>
              </Container>
            )}
            {isSignup && (
              <Signup setIsSignup={setIsSignup} setIsLogin={setIsLogin} />
            )}
          </Backdrop>
    ```
    

## 문제

- 각각 모달과 배경에 애니메이션 효과를 준 다음 확인을 해보다가 아래와 같이 회원가입 ⇒ 로그인으로 이동할 때 배경이 다시 밝아지는 것을 발견했다.
    ![모달트랜지션문제점](https://user-images.githubusercontent.com/95751232/225537326-afb9ee7f-b0a8-419a-9201-5c236cef78cc.gif)

    

## 원인

- 현재 로그인 컴포넌트와 회원가입 컴포넌트의 배치 구조는 아래와 같이 병렬적으로 되어있다. (App 컴포넌트 안에서) 로그인 모달에서 회원가입 모달로 가려면 로그인 모달이 사라지고 회원가입 모달이 뜨면서 각각의 배경들도 어두워졌다 밝아졌다가 총 두번 나타나기 때문에 위의 움짤 쳐럼 나타나는 거였다.
    
    ```tsx
    {openLoginModal && (
        <LoginModal
          loginHandler={loginHandler}
          setLoginModal={setLoginModal}
          setSignupModal={setSignupModal}
        />
    )}
    {openSignupModal && (
    			<SignupModal
    			setSignupModal={setSignupModal}
    			setLoginModal={setLoginModal}
    			/>
    )}
    ```
    

## 해결방안

- 로그인 모달을 띄운 경우에만 회원가입 모달로 갈 수 있도록 설계를 했기 때문에 일단 로그인 모달을 띄우면 그안에서 뒷배경은 계속 어둡게 되어있고 로그인 모달이 뜨던지 회원가입 모달이 뜨던지 자유자재로 할 수 있게 하는게 우선이었다.
- 그래서 위의 배치 처럼 병렬적으로 모달들을 나열하기 보단, 로그인 모달에서 회원가입 모달을 보여주도록 품는게 더 나을 것이라는 판단이 들었다.
- App 컴포넌트에서는 아래와 같이 회원가입 모달을 없애고 로그인 모달만 띄워주기로 하고
    
    ```tsx
    {isLoginModal && (
                  <Login
                    loginHandler={loginHandler}
                    setIsLoginModal={setIsLoginModal}
                  />
                )}
    ```
    
- 로그인 모달 안에서 로그인 컴포넌트와 회원가입 컴포넌트를 flag변수로 왔다갔다 보여주도록 구현하였다.
    
    ```tsx
    <Backdrop onClick={modalClose} isHide={isHide}>
            {isLogin &&  <Container /> }
    
            {isSignup && (
              <Signup setIsSignup={setIsSignup} setIsLogin={setIsLogin} />
            )}
    </Backdrop>
    ```
    

## 시연

- 로그인 모달이 띄워진 이후로 자연스럽게 두 컴포넌트들을 왔다갔다 하도록 보여진다.
 ![모달 변경후](https://user-images.githubusercontent.com/95751232/225537386-086e8b53-ce54-4d60-8f64-819ecefaa15c.gif)
